### PR TITLE
Adding multicodec for aes-gcm

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -69,6 +69,7 @@ aes-192,                        key,            0xa1,           draft,     192-b
 aes-256,                        key,            0xa2,           draft,     256-bit AES symmetric key
 chacha-128,                     key,            0xa3,           draft,     128-bit ChaCha symmetric key
 chacha-256,                     key,            0xa4,           draft,     256-bit ChaCha symmetric key
+aes-gcm-256,                    encryption,     0xa5,           draft,     AES Galois/Counter Mode with 256-bit key and 12-byte IV
 bitcoin-block,                  ipld,           0xb0,           permanent, Bitcoin Block
 bitcoin-tx,                     ipld,           0xb1,           permanent, Bitcoin Tx
 bitcoin-witness-commitment,     ipld,           0xb2,           permanent, Bitcoin Witness Commitment


### PR DESCRIPTION
Adding `aes-gcm-256` multicodec. Pleas edit if the category `encryption` doesn't fit here.

`aes-gcm-256` is a payload format: the 12-byte Initialization Vector (IV) is concatenated with a payload encrypted using AES in Galois/Counter Mode, using a 256-bit key and the 12 byte IV.

This multicodec is required for the Double Hash DHT https://github.com/ipfs/specs/pull/373